### PR TITLE
🚧 Test ElixirSyntax syntax highlighting to supports heex templates

### DIFF
--- a/sublime-text-3/Package Control.sublime-settings
+++ b/sublime-text-3/Package Control.sublime-settings
@@ -12,6 +12,7 @@
 		"DocBlockr",
 		"Dockerfile Syntax Highlighting",
 		"Elixir",
+		"ElixirSyntax",
 		"gruvbox",
 		"Ignore Unable to Open File Error",
 		"JavaScript Completions",


### PR DESCRIPTION
Can't use this for now, do funny things with `@doc` block...